### PR TITLE
chore: Removed invoking write_to_file after code generation

### DIFF
--- a/four-bit-computer/assembler/assembler.py
+++ b/four-bit-computer/assembler/assembler.py
@@ -3,7 +3,7 @@
 import sys
 from scanner import Scanner
 from parser import Parser
-from code_generator import CodeGenerator
+from code_generator import CodeGenerator, FileType
 
 if __name__ == "__main__":
 
@@ -26,3 +26,5 @@ if __name__ == "__main__":
     code_generator = CodeGenerator(parser.get_instructions)
     code_generator.generate_binary_code()
     code_generator.generate_hex_code()
+    code_generator.write_to_file(FileType.BINARY_FILE)
+    code_generator.write_to_file(FileType.HEX_FILE)

--- a/four-bit-computer/assembler/code_generator.py
+++ b/four-bit-computer/assembler/code_generator.py
@@ -4,11 +4,13 @@ from typing import List
 from instruction import Instruction
 
 
+class FileType(Enum):
+    HEX_FILE    = "HEX_FILE"
+    BINARY_FILE = "BIN_FILE"
+
+
 class CodeGenerator:
 
-    class FileType(Enum):
-        HEX_FILE    = "HEX_FILE"
-        BINARY_FILE = "BIN_FILE"
     
     # File data
     OUTPUT_DIR      = "output"
@@ -31,13 +33,10 @@ class CodeGenerator:
         self.binary_code    = []
         self.hex_code       = []
 
-        os.makedirs(self.OUTPUT_DIR, exist_ok=True)
-
     def generate_binary_code(self):
         for instruction in self.instructions:
             binary_code = self.opcodes.get(instruction.mnemonic) + str(instruction.data)
             self.binary_code.append(binary_code)
-        self.write_to_file(self.FileType.BINARY_FILE)
 
     def generate_hex_code(self):
         for instruction in self.instructions:
@@ -47,7 +46,6 @@ class CodeGenerator:
             hex_code = (opcode << 1) | (data & 1)
             hex_instruction = "{:x}".format(hex_code)
             self.hex_code.append(hex_instruction)
-        self.write_to_file(self.FileType.HEX_FILE)
 
     def write_to_file(self, file_type: FileType):
         instructions: str = self.binary_code if file_type.value == "BIN_FILE" else self.hex_code

--- a/four-bit-computer/instructions.txt
+++ b/four-bit-computer/instructions.txt
@@ -13,9 +13,9 @@ JMP 1   ; jumps to address 1
 
 ; Implementing labels in my assembly
 
-JMP TEST_1
+;JMP TEST_1
 
-TEST_1:
-    LOAD 1
-    ADD 1
-    JMP 1
+;TEST_1:
+;    LOAD 1
+;    ADD 1
+;    JMP 1


### PR DESCRIPTION
### Overview
- Removed invoking `write_to_file` right after code generation
- Instead we call this function explicitly to write the output to a file.

### Why this change?
- Helps with writing unit test to test the actual functionality of code generation instead of mocking file operations.