### PR TITLE
fix: JMP instruction

### DIFF
--- a/four-bit-computer/assembler/parser.py
+++ b/four-bit-computer/assembler/parser.py
@@ -28,7 +28,11 @@ class Parser:
         current_token: Token = self.advance()
         operand: int = int(current_token.lexeme)
 
-        if operand not in [0, 1]:
+        # For the JMP instruction, the value of the operand can be from 0 to 15
+        # For the remaining instructions, the value of the operand will be either 0 or 1
+        if mnemonic == TokenType.JMP.value and (operand < 0 or operand > 15):
+            raise SyntaxError(f"Unknown operand: {operand} at line number: {current_token.line} for JMP instruction")
+        elif (operand not in [0, 1]) and not (mnemonic == TokenType.JMP.value):
             raise SyntaxError(f"Unknown operand: {operand} at line number: {current_token.line}")
 
         return Instruction(mnemonic, operand)


### PR DESCRIPTION
### Overview
- The value of operand have been hardcoded as 0 and 1.
- This works for instructions other than `JMP`.
- The acceptable value for the `JMP` instruction is between 0 and 15.
- So that we can move to different sections of code using `JMP` instruction.