### PR TITLE
fix: Revert JMP instruction operand parsing

### DIFF
--- a/four-bit-computer/assembler/parser.py
+++ b/four-bit-computer/assembler/parser.py
@@ -33,11 +33,7 @@ class Parser:
             current_token: Token = self.advance()
             operand: int = int(current_token.lexeme)
 
-        # For the JMP instruction, the value of the operand can be from 0 to 15
-        # For the remaining instructions, the value of the operand will be either 0 or 1
-        if mnemonic == TokenType.JMP.value and (operand < 0 or operand > 15):
-            raise SyntaxError(f"Unknown operand: {operand} at line number: {current_token.line} for JMP instruction")
-        elif (operand not in [0, 1]) and not (mnemonic == TokenType.JMP.value):
+        if operand not in [0, 1]:
             raise SyntaxError(f"Unknown operand: {operand} at line number: {current_token.line}")
 
         return Instruction(mnemonic, operand)


### PR DESCRIPTION
### Overview
- Since `four-bit-computer` uses 1 bit for data, it can't support encoding values other than 0 or 1.
- So its not possible to write instructions like `JMP 2` or `JMP 2`

### Valid
```
JMP 0
JMP 1
```

### Invalid
```
JMP 4
JMP 6
``` 